### PR TITLE
Add CIFAR-10, CIFAR-100, and STL-10 datasets and baseline models

### DIFF
--- a/sesemi/datasets.py
+++ b/sesemi/datasets.py
@@ -5,9 +5,9 @@
 import os
 
 from torch.utils.data import ConcatDataset, Dataset, IterableDataset
-from torchvision.datasets import ImageFolder
+from torchvision.datasets import ImageFolder, CIFAR10, CIFAR100, STL10
 
-from typing import Callable, Dict, List, Optional, Union
+from typing import Callable, Dict, List, Optional, Type, Union
 
 DatasetBuilder = Callable[..., Union[Dataset, IterableDataset]]
 ImageTransform = Callable
@@ -61,6 +61,165 @@ def image_folder(
 
         dsts = [
             ImageFolder(os.path.join(root, s), transform=image_transform)
+            for s in subsets
+        ]
+
+        return ConcatDataset(dsts)
+
+
+def _cifar(
+    dataset_cls: Union[Type[CIFAR10], Type[CIFAR100]],
+    root: str,
+    subset: Optional[Union[str, List[str]]] = None,
+    image_transform: Optional[ImageTransform] = None,
+    **kwargs,
+) -> Dataset:
+    """A CIFAR dataset builder.
+
+    Args:
+        dataset_cls: One of (CIFAR10, CIFAR100).
+        root: The path to the image folder dataset.
+        subset: The subset(s) to use. Subets include (train, test).
+        image_transform: The image transformations to apply.
+
+    Returns:
+        An `ImageFolder` dataset.
+    """
+    if isinstance(subset, str):
+        assert subset in {
+            "train",
+            "test",
+        }, f"invalid subset {subset}, only support {{train, test}}"
+        train = subset == "train"
+        return dataset_cls(
+            root,
+            train=train,
+            download=True,
+            transform=image_transform,
+        )
+    else:
+        if subset is None:
+            subsets = ["train", "test"]
+        else:
+            subsets = subset
+
+        for s in subsets:
+            assert s in {
+                "train",
+                "test",
+            }, f"invalid subset {subset}, only support {{train, test}}"
+
+        dsts = [
+            dataset_cls(
+                root,
+                train=(s == "train"),
+                download=True,
+                transform=image_transform,
+            )
+            for s in subsets
+        ]
+
+        return ConcatDataset(dsts)
+
+
+@register_dataset
+def cifar10(
+    root: str,
+    subset: Optional[Union[str, List[str]]] = None,
+    image_transform: Optional[ImageTransform] = None,
+    **kwargs,
+) -> Dataset:
+    """A CIFAR-10 dataset builder.
+
+    Args:
+        root: The path to the image folder dataset.
+        subset: The subset(s) to use. Subets include (train, test).
+        image_transform: The image transformations to apply.
+
+    Returns:
+        An `ImageFolder` dataset.
+    """
+    return _cifar(
+        CIFAR10, root, subset=subset, image_transform=image_transform, **kwargs
+    )
+
+
+@register_dataset
+def cifar100(
+    root: str,
+    subset: Optional[Union[str, List[str]]] = None,
+    image_transform: Optional[ImageTransform] = None,
+    **kwargs,
+) -> Dataset:
+    """A CIFAR-100 dataset builder.
+
+    Args:
+        root: The path to the image folder dataset.
+        subset: The subset(s) to use. Subets include (train, test).
+        image_transform: The image transformations to apply.
+
+    Returns:
+        An `ImageFolder` dataset.
+    """
+    return _cifar(
+        CIFAR100, root, subset=subset, image_transform=image_transform, **kwargs
+    )
+
+
+@register_dataset
+def stl10(
+    root: str,
+    subset: Optional[Union[str, List[str]]] = None,
+    image_transform: Optional[ImageTransform] = None,
+    **kwargs,
+) -> Dataset:
+    """An STL10 dataset builder.
+
+    Args:
+        root: The path to the image folder dataset.
+        subset: The subset(s) to use. Subets include
+            (train, test, unlabeled, train+unlabeled).
+        image_transform: The image transformations to apply.
+
+    Returns:
+        An `ImageFolder` dataset.
+    """
+    if isinstance(subset, str):
+        assert subset in {
+            "train",
+            "test",
+            "unlabeled",
+            "train+unlabeled",
+        }, f"invalid subset {subset}, only support {{train, test, unlabeled, train+unlabeled}}"
+        return STL10(
+            root,
+            split=subset,
+            download=True,
+            transform=image_transform,
+            **kwargs,
+        )
+    else:
+        if subset is None:
+            subsets = ["train", "test", "unlabeled"]
+        else:
+            subsets = subset
+
+        for s in subsets:
+            assert s in {
+                "train",
+                "test",
+                "unlabeled",
+                "train+unlabeled",
+            }, f"invalid subset {subset}, only support {{train, test, unlabeled, train+unlabeled}}"
+
+        dsts = [
+            STL10(
+                root,
+                split=s,
+                download=True,
+                transform=image_transform,
+                **kwargs,
+            )
             for s in subsets
         ]
 

--- a/sesemi/models/backbones/__init__.py
+++ b/sesemi/models/backbones/__init__.py
@@ -2,3 +2,4 @@
 # Copyright 2021, Flyreel. All Rights Reserved.
 # =============================================#
 """Backbone models."""
+from . import base, resnet, timm

--- a/sesemi/models/backbones/resnet.py
+++ b/sesemi/models/backbones/resnet.py
@@ -1,0 +1,209 @@
+"""Specialized residual networks."""
+from typing import Optional
+from torch import nn
+
+import torch.nn.functional as F
+
+from .base import Backbone
+
+
+class CIFARResidualBlock(nn.Module):
+    """A residual block for the CIFARResNet backbone."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: Optional[int] = None,
+        downsample: bool = False,
+    ):
+        """Initializes the residual block.
+
+        Args:
+            in_channels: The number of input channels.
+            out_channels: The number of output channels. Defaults to the number of
+                inputs.
+            downsamples: Whether to downsample the inputs using a stride of 2.
+        """
+        super().__init__()
+        if out_channels is None:
+            out_channels = in_channels
+
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+
+        self.conv1 = nn.Conv2d(
+            in_channels=in_channels,
+            out_channels=out_channels,
+            kernel_size=3,
+            stride=2 if downsample else 1,
+            padding=1,
+            bias=False,
+        )
+        self.bn1 = nn.BatchNorm2d(out_channels)
+        self.relu = nn.ReLU(inplace=True)
+        self.conv2 = nn.Conv2d(
+            in_channels=out_channels,
+            out_channels=out_channels,
+            kernel_size=3,
+            stride=1,
+            padding=1,
+            bias=False,
+        )
+        self.bn2 = nn.BatchNorm2d(out_channels)
+        self.downsample = downsample
+
+    def forward(self, inputs):
+        conv1 = self.conv1(inputs)
+        bn1 = self.bn1(conv1)
+        relu1 = self.relu(bn1)
+        conv2 = self.conv2(relu1)
+        residual = self.bn2(conv2)
+
+        if self.downsample:
+            xi = F.interpolate(
+                inputs, size=(residual.shape[2], residual.shape[3]), mode="nearest"
+            )
+        else:
+            xi = inputs
+
+        channel_difference = self.out_channels - self.in_channels
+        if channel_difference > 0:
+            xi = F.pad(
+                xi,
+                (0, 0, 0, 0, 0, channel_difference, 0, 0),
+                mode="constant",
+                value=0,
+            )
+
+        y = residual + xi
+        outputs = self.relu(y)
+        return outputs
+
+
+class CIFARDeepResidualBlock(nn.Module):
+    """A deep residual block for the CIFARResNet backbone."""
+
+    def __init__(
+        self,
+        num_residual_blocks: int,
+        in_channels: int,
+        out_channels: Optional[int] = None,
+        downsample: bool = False,
+    ):
+        """Initializes the deep residual block.
+
+        Args:
+            num_residual_blocks: The number of residual block to chain together.
+            in_channels: The number of input channels.
+            out_channels: The number of output channels. Defaults to the number of
+                inputs.
+            downsamples: Whether to downsample the inputs using a stride of 2.
+        """
+        super().__init__()
+        if out_channels is None:
+            out_channels = in_channels
+
+        self.num_residual_blocks = num_residual_blocks
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.downsample = downsample
+
+        block_layers = [
+            CIFARResidualBlock(
+                in_channels=in_channels,
+                out_channels=out_channels,
+                downsample=downsample,
+            )
+        ]
+        for _ in range(num_residual_blocks - 1):
+            block_layers.append(CIFARResidualBlock(in_channels=out_channels))
+
+        self.block = nn.Sequential(*block_layers)
+
+    def forward(self, inputs):
+        return self.block(inputs)
+
+
+class CIFARResNet(Backbone):
+    """A specialized ResNet designed for CIFAR10 and described in the referenced paper.
+
+    @article{He2016DeepRL,
+        title={Deep Residual Learning for Image Recognition},
+        author={Kaiming He and X. Zhang and Shaoqing Ren and Jian Sun},
+        journal={2016 IEEE Conference on Computer Vision and Pattern Recognition (CVPR)},
+        year={2016},
+        pages={770-778}
+    }
+
+    See section 4.2 for the CIFAR-10 network design and analysis.
+    """
+
+    def __init__(
+        self,
+        linear_features: Optional[int] = None,
+        n: int = 18,
+        drop_rate: float = 0.0,
+    ):
+        """Initializes the ResNet.
+
+        Args:
+            linear_features: An optional specification for an additional linear layer
+                to use at the end of the network. Otherwise the outputs are 64d and no
+                linear layer is applied.
+            n: This parameter defines a multiplier for the number of layers in use. The
+                total layers not counting any added linear linear is 6 * n + 1. The
+                default value for n would then result in 109 (6 * 18 + 1) layers. With
+                an added linear layer this is 110.
+            drop_rate: The dropout rate to use on the output features.
+        """
+        super().__init__()
+
+        self.in_features = 3
+        self.out_features = 64 if linear_features is None else linear_features
+
+        self.conv1 = nn.Conv2d(
+            in_channels=3,
+            out_channels=16,
+            kernel_size=3,
+            stride=1,
+            padding=1,
+            bias=False,
+        )
+        self.bn1 = nn.BatchNorm2d(16)
+        self.relu = nn.ReLU(inplace=True)
+
+        self.block1 = CIFARDeepResidualBlock(n, in_channels=16)
+        self.block2 = CIFARDeepResidualBlock(
+            n, in_channels=16, out_channels=32, downsample=True
+        )
+        self.block3 = CIFARDeepResidualBlock(
+            n, in_channels=32, out_channels=64, downsample=True
+        )
+
+        self.pooling = nn.AdaptiveAvgPool2d(1)
+
+        if linear_features is not None:
+            self.linear_block: Optional[nn.Sequential] = nn.Sequential(
+                nn.Linear(64, linear_features, bias=False),
+                nn.BatchNorm1d(linear_features),
+                nn.ReLU(inplace=True),
+            )
+        else:
+            self.linear_block = None
+
+        self.dropout = nn.Dropout(p=drop_rate, inplace=True)
+
+    def forward(self, inputs):
+        conv1 = self.conv1(inputs)
+        bn1 = self.bn1(conv1)
+        relu1 = self.relu(bn1)
+        block1 = self.block1(relu1)
+        block2 = self.block2(block1)
+        block3 = self.block3(block2)
+        features = self.pooling(block3)[..., 0, 0]
+
+        if self.linear_block is not None:
+            features = self.linear_block(features)
+
+        outputs = self.dropout(features)
+        return outputs

--- a/sesemi/trainer/conf/base/supervised/backbone/cifar_resnet.yaml
+++ b/sesemi/trainer/conf/base/supervised/backbone/cifar_resnet.yaml
@@ -1,0 +1,8 @@
+# @package _global_
+learner:
+  hparams:
+    model:
+      backbone:
+        _target_: sesemi.models.backbones.resnet.CIFARResNet
+        n: 18
+        drop_rate: 0.5

--- a/sesemi/trainer/conf/base/supervised/backbone/timm.yaml
+++ b/sesemi/trainer/conf/base/supervised/backbone/timm.yaml
@@ -1,0 +1,11 @@
+# @package _global_
+learner:
+  hparams:
+    model:
+      backbone:
+        _target_: sesemi.PyTorchImageModels
+        name: resnet50d
+        freeze: False
+        pretrained: False
+        global_pool: avg
+        drop_rate: 0.5

--- a/sesemi/trainer/conf/base/supervised/data/cifar10.yaml
+++ b/sesemi/trainer/conf/base/supervised/data/cifar10.yaml
@@ -1,0 +1,28 @@
+# @package _global_
+run:
+  data_root: ./data/cifar10
+learner:
+  hparams:
+    num_classes: 10
+data:
+  train:
+    supervised:
+      dataset:
+        name: cifar10
+        subset: train
+        image_transform:
+          _target_: sesemi.transforms.cifar_train_transforms
+      shuffle: True
+      pin_memory: True
+      num_workers: 4
+      drop_last: True
+  val:
+    dataset:
+      name: cifar10
+      subset: test
+      image_transform:
+        _target_: sesemi.transforms.cifar_test_transforms
+    shuffle: False
+    pin_memory: True
+    num_workers: 4
+    drop_last: False

--- a/sesemi/trainer/conf/base/supervised/data/cifar100.yaml
+++ b/sesemi/trainer/conf/base/supervised/data/cifar100.yaml
@@ -1,0 +1,8 @@
+# @package _global_
+defaults:
+- /base/supervised/data/cifar10
+run:
+  data_root: ./data/cifar100
+learner:
+  hparams:
+    num_classes: 100

--- a/sesemi/trainer/conf/base/supervised/data/stl10.yaml
+++ b/sesemi/trainer/conf/base/supervised/data/stl10.yaml
@@ -1,0 +1,34 @@
+# @package _global_
+run:
+  data_root: ./data/stl10
+learner:
+  hparams:
+    num_classes: 10
+data:
+  train:
+    supervised:
+      dataset:
+        name: stl10
+        subset: train
+        image_transform:
+          _target_: sesemi.transforms.train_transforms
+          random_resized_crop: True
+          resize: 100
+          crop_dim: 96
+          scale: [0.3, 1.0]
+      shuffle: True
+      pin_memory: True
+      num_workers: 4
+      drop_last: True
+  val:
+    dataset:
+      name: stl10
+      subset: test
+      image_transform:
+        _target_: sesemi.transforms.center_crop_transforms
+        resize: 96
+        crop_dim: 96
+    shuffle: False
+    pin_memory: True
+    num_workers: 4
+    drop_last: False

--- a/sesemi/trainer/conf/base/supervised/lr_scheduler/cosine.yaml
+++ b/sesemi/trainer/conf/base/supervised/lr_scheduler/cosine.yaml
@@ -1,0 +1,7 @@
+# @package _global_
+learner:
+  hparams:
+    lr_scheduler:
+      scheduler:
+        _target_: torch.optim.lr_scheduler.CosineAnnealingLR
+        T_max: ${sesemi:max_iterations}

--- a/sesemi/trainer/conf/base/supervised/lr_scheduler/polynomial.yaml
+++ b/sesemi/trainer/conf/base/supervised/lr_scheduler/polynomial.yaml
@@ -1,0 +1,11 @@
+# @package _global_
+learner:
+  hparams:
+    lr_scheduler:
+      scheduler:
+        _target_: sesemi.PolynomialLR
+        warmup_epochs: 10
+        iters_per_epoch: ${sesemi:iterations_per_epoch}
+        warmup_lr: 0.001
+        lr_pow: 0.5
+        max_iters: ${sesemi:max_iterations}

--- a/sesemi/trainer/conf/base/supervised/model.yaml
+++ b/sesemi/trainer/conf/base/supervised/model.yaml
@@ -7,30 +7,9 @@ run:
 learner:
   hparams:
     model:
-      backbone:
-        _target_: sesemi.PyTorchImageModels
-        name: resnet50d
-        freeze: False
-        pretrained: False
-        global_pool: avg
-        drop_rate: 0.5
       supervised_loss:
         callable:
           _target_: torch.nn.CrossEntropyLoss
-    optimizer:
-      _target_: torch.optim.SGD
-      lr: 0.1
-      momentum: 0.9
-      nesterov: True
-      weight_decay: 0.0005
-    lr_scheduler:
-      scheduler:
-        _target_: sesemi.PolynomialLR
-        warmup_epochs: 10
-        iters_per_epoch: ${sesemi:iterations_per_epoch}
-        warmup_lr: 0.001
-        lr_pow: 0.5
-        max_iters: ${sesemi:max_iterations}
 trainer:
   callbacks:
     - _target_: pytorch_lightning.callbacks.ModelCheckpoint

--- a/sesemi/trainer/conf/base/supervised/model/baseline.yaml
+++ b/sesemi/trainer/conf/base/supervised/model/baseline.yaml
@@ -1,0 +1,6 @@
+# @package _global_
+defaults:
+  - /base/supervised/model
+  - /base/supervised/backbone/timm
+  - /base/supervised/optimizer/sgd
+  - /base/supervised/lr_scheduler/polynomial

--- a/sesemi/trainer/conf/base/supervised/optimizer/sgd.yaml
+++ b/sesemi/trainer/conf/base/supervised/optimizer/sgd.yaml
@@ -1,0 +1,9 @@
+# @package _global_
+learner:
+  hparams:
+    optimizer:
+      _target_: torch.optim.SGD
+      lr: 0.1
+      momentum: 0.9
+      nesterov: True
+      weight_decay: 0.0005

--- a/sesemi/trainer/conf/cifar10.yaml
+++ b/sesemi/trainer/conf/cifar10.yaml
@@ -1,0 +1,13 @@
+# @package _global_
+defaults:
+  - /base/supervised/model
+  - /base/supervised/backbone/cifar_resnet
+  - /base/supervised/optimizer/sgd
+  - /base/supervised/lr_scheduler/polynomial
+  - /base/supervised/data/cifar10
+run:
+  seed: 42
+  gpus: 1
+  batch_size_per_gpu: 512
+  num_epochs: 800
+  id: cifar10

--- a/sesemi/trainer/conf/cifar100.yaml
+++ b/sesemi/trainer/conf/cifar100.yaml
@@ -1,0 +1,13 @@
+# @package _global_
+defaults:
+  - /base/supervised/model
+  - /base/supervised/backbone/cifar_resnet
+  - /base/supervised/optimizer/sgd
+  - /base/supervised/lr_scheduler/polynomial
+  - /base/supervised/data/cifar100
+run:
+  seed: 42
+  gpus: 1
+  batch_size_per_gpu: 512
+  num_epochs: 800
+  id: cifar100

--- a/sesemi/trainer/conf/imagewang_consistency.yaml
+++ b/sesemi/trainer/conf/imagewang_consistency.yaml
@@ -1,6 +1,6 @@
 # @package _global_
 defaults:
-  - /base/supervised/model
+  - /base/supervised/model/baseline
   - /base/supervised/data/imagewang
   - /base/consistency_minimization/model
 run:

--- a/sesemi/trainer/conf/imagewang_entmin.yaml
+++ b/sesemi/trainer/conf/imagewang_entmin.yaml
@@ -1,6 +1,6 @@
 # @package _global_
 defaults:
-  - /base/supervised/model
+  - /base/supervised/model/baseline
   - /base/supervised/data/imagewang
   - /base/entropy_minimization/model
   - /base/entropy_minimization/data/imagewang

--- a/sesemi/trainer/conf/imagewang_jigsaw.yaml
+++ b/sesemi/trainer/conf/imagewang_jigsaw.yaml
@@ -1,6 +1,6 @@
 # @package _global_
 defaults:
-  - /base/supervised/model
+  - /base/supervised/model/baseline
   - /base/supervised/data/imagewang
   - /base/jigsaw_prediction/model
   - /base/jigsaw_prediction/data/imagewang

--- a/sesemi/trainer/conf/imagewang_jigsaw_entmin.yaml
+++ b/sesemi/trainer/conf/imagewang_jigsaw_entmin.yaml
@@ -1,6 +1,6 @@
 # @package _global_
 defaults:
-  - /base/supervised/model
+  - /base/supervised/model/baseline
   - /base/supervised/data/imagewang
   - /base/jigsaw_prediction/model
   - /base/jigsaw_prediction/data/imagewang

--- a/sesemi/trainer/conf/imagewang_rotation.yaml
+++ b/sesemi/trainer/conf/imagewang_rotation.yaml
@@ -1,6 +1,6 @@
 # @package _global_
 defaults:
-  - /base/supervised/model
+  - /base/supervised/model/baseline
   - /base/supervised/data/imagewang
   - /base/rotation_prediction/model
   - /base/rotation_prediction/data/imagewang

--- a/sesemi/trainer/conf/imagewang_rotation_entmin.yaml
+++ b/sesemi/trainer/conf/imagewang_rotation_entmin.yaml
@@ -1,6 +1,6 @@
 # @package _global_
 defaults:
-  - /base/supervised/model
+  - /base/supervised/model/baseline
   - /base/supervised/data/imagewang
   - /base/rotation_entropy_minimization/model
   - /base/rotation_entropy_minimization/data/imagewang

--- a/sesemi/trainer/conf/imagewoof.yaml
+++ b/sesemi/trainer/conf/imagewoof.yaml
@@ -1,6 +1,6 @@
 # @package _global_
 defaults:
-  - /base/supervised/model
+  - /base/supervised/model/baseline
   - /base/supervised/data/imagewoof
 run:
   seed: 42

--- a/sesemi/trainer/conf/imagewoof_entmin.yaml
+++ b/sesemi/trainer/conf/imagewoof_entmin.yaml
@@ -1,6 +1,6 @@
 # @package _global_
 defaults:
-  - /base/supervised/model
+  - /base/supervised/model/baseline
   - /base/supervised/data/imagewoof
   - /base/entropy_minimization/model
   - /base/entropy_minimization/data/imagenet

--- a/sesemi/trainer/conf/imagewoof_rotation.yaml
+++ b/sesemi/trainer/conf/imagewoof_rotation.yaml
@@ -1,6 +1,6 @@
 # @package _global_
 defaults:
-  - /base/supervised/model
+  - /base/supervised/model/baseline
   - /base/supervised/data/imagewoof
   - /base/rotation_prediction/model
   - /base/rotation_prediction/data/imagenet

--- a/sesemi/trainer/conf/stl10.yaml
+++ b/sesemi/trainer/conf/stl10.yaml
@@ -1,10 +1,10 @@
 # @package _global_
 defaults:
   - /base/supervised/model/baseline
-  - /base/supervised/data/imagewang
+  - /base/supervised/data/stl10
 run:
   seed: 42
   gpus: 2
-  batch_size_per_gpu: 32
+  batch_size_per_gpu: 128
   num_epochs: 800
-  id: imagewang
+  id: stl10


### PR DESCRIPTION
Refactoring of #26.

* Adds support for the CIFAR10, CIFAR100, and STL10 datasets.
* Adds the CIFAR-variant of ResNets as described in:
  ```bibtex
  @article{He2016DeepRL,
    title={Deep Residual Learning for Image Recognition},
    author={Kaiming He and X. Zhang and Shaoqing Ren and Jian Sun},
    journal={2016 IEEE Conference on Computer Vision and Pattern Recognition (CVPR)},
    year={2016},
    pages={770-778}
  }
  ```
* Refactors the supervised model config out into backbones, optimizers, and learning rate schedulers and defines a baseline model config.